### PR TITLE
Fix possible make clean error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ test:
 	$(CC) -o quich_test $(FILES) tests/main.c -lm
 
 clean:
-	rm $(NAME)
+	$(RM) $(NAME)


### PR DESCRIPTION
Use $(RM), provided by built-in make rules can prevent the possible "No such file or directory" error for `make clean` Makefile target.