### PR TITLE
Fix cp error when NAME != quich

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ quich: $(FILES)
 
 install: quich
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	cp $< $(DESTDIR)$(PREFIX)/bin/$(NAME)
+	cp $(NAME) $(DESTDIR)$(PREFIX)/bin/$(NAME)
 
 test:
 	$(CC) -o quich_test $(FILES) tests/main.c -lm


### PR DESCRIPTION
Compiling with `sudo make install NAME=calc` for example results in
```
gcc -o calc src/helper.c src/parser.c src/lexer.c src/variable.c src/quich.c -lm -std=c99 -pedantic -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition
mkdir -p /usr/local/bin
cp quich /usr/local/bin/calc
cp: cannot stat 'quich': No such file or directory
make: *** [Makefile:16: install] Error 1
```
This fixes that