### PR TITLE
Add LDFLAGS option to MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC=gcc
 CFLAGS=-lm -std=c99 -pedantic -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition
+LDFLAGS=
 FILES=src/helper.c src/parser.c src/lexer.c src/variable.c
 PREFIX=/usr/local
 ifndef NAME
@@ -9,7 +10,7 @@ endif
 all: quich
 
 quich: $(FILES)
-	$(CC) -o $(NAME) $(FILES) src/quich.c $(CFLAGS)
+	$(CC) -o $(NAME) $(FILES) src/quich.c $(CFLAGS) $(LDFLAGS)
 
 install: quich
 	mkdir -p $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
This change helps package maintainers easily append distribution specific `LDFLAGS` to the compilation process.