### PR TITLE
Make the getPrec function simpler and more efficient

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
@@ -268,29 +269,10 @@ void initList(struct list **list)
 
 int getPrec(enum OPCODE opcode)
 {
-    if (opcode == OP_Equal) {
-        return 5;
+    int prec[8] = {5, 4, 4, 3, 3, 2, 2, 1};
+    if (opcode < sizeof(prec)) {
+	    return prec[opcode];
     }
-
-    if (opcode == OP_Open_parenthesis ||
-        opcode == OP_Closed_parenthesis) {
-        return 4;
-    }
-
-    if (opcode == OP_Plus ||
-        opcode == OP_Minus) {
-        return 3;
-    }
-
-    if (opcode == OP_Multi ||
-        opcode == OP_Div) {
-        return 2;
-    }
-
-    if (opcode == OP_Pow) {
-        return 1;
-    }
-
     return 0;
 }
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -10,12 +10,15 @@ enum TOKEN_TYPE {
     T_None
 };
 
+// A change to this enum should be coupled with a change to getPrec in lexer.c
 enum OPCODE {
+    OP_Equal,
+    OP_Open_parenthesis,
+    OP_Closed_parenthesis,
     OP_Plus,
     OP_Minus,
     OP_Multi,
     OP_Div,
-    OP_Equal,
     OP_Pow,
     OP_Fact,
     OP_Sqrt,
@@ -35,8 +38,6 @@ enum OPCODE {
     OP_Asin,
     OP_Acos,
     OP_Atan,
-    OP_Closed_parenthesis,
-    OP_Open_parenthesis,
     OP_None,
 };
 


### PR DESCRIPTION
This PR is supposed to make the getPrec function simpler and more efficient. One con is that the enum's order matters. 