### PR TITLE
CMake: Allow external linking of linenoise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,49 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.17)
 project(quich)
 
 set(CMAKE_CXX_STANDARD 11)
 
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+    pkg_search_module(LINENOISE liblinenoise)
+endif()
+
 add_executable(quich
-        lib/linenoise.c lib/linenoise.h
         src/lexer.c src/lexer.h
         src/parser.c src/parser.h
         src/helper.c src/helper.h
         src/variable.c src/variable.h
         src/quich.c src/quich.h)
 
+if(LINENOISE_FOUND)
+    message(STATUS "Found linenoise: ${LINENOISE_INCLUDEDIR} (found version \"${LINENOISE_VERSION}\")")
+    target_include_directories(quich PRIVATE ${LINENOISE_INCLUDE_DIRS})
+    target_link_directories(quich PRIVATE ${LINENOISE_LIBRARY_DIRS})
+    target_link_libraries(quich ${LINENOISE_LIBRARIES})
+else()
+    message(STATUS "linenoise not found, using bundled version")
+    target_sources(quich PRIVATE
+        lib/linenoise.c lib/linenoise.h)
+    target_include_directories(quich PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+endif()
+
 target_link_libraries(quich m)
 
 add_executable(quich_test
-        lib/linenoise.c lib/linenoise.h
         src/lexer.c src/lexer.h
         src/parser.c src/parser.h
         src/helper.c src/helper.h
         src/variable.c src/variable.h
         tests/main.c)
+
+if(LINENOISE_FOUND)
+    target_include_directories(quich_test PRIVATE ${LINENOISE_INCLUDE_DIRS})
+    target_link_directories(quich_test PRIVATE ${LINENOISE_LIBRARY_DIRS})
+    target_link_libraries(quich_test ${LINENOISE_LIBRARIES})
+else()
+    target_sources(quich_test PRIVATE
+        lib/linenoise.c lib/linenoise.h)
+    target_include_directories(quich_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+endif()
 
 target_link_libraries(quich_test m)

--- a/src/quich.c
+++ b/src/quich.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>
-#include "../lib/linenoise.h"
+#include <linenoise.h>
 #include "helper.h"
 #include "lexer.h"
 #include "parser.h"


### PR DESCRIPTION
Add support for using pkg-config to find external version of (lib)linenoise